### PR TITLE
Change 1/2 to A/B for consistency in Gather

### DIFF
--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -67,13 +67,13 @@
   time_start: "13:15"
   time_end: "14:00"
   session: roundtable
-  platform: Zoom 1
+  platform: Zoom A
 - name: Focused discussion
   date: 20210608
   time_start: "13:15"
   time_end: "14:00"
   session: breakout
-  platform: Zoom 2
+  platform: Zoom B
 - name: Social break
   date: 20210608
   time_start: "14:00"
@@ -84,13 +84,13 @@
   time_start: "14:15"
   time_end: "15:00"
   session: workshop
-  platform: Zoom 1
+  platform: Zoom A
 - name: Focused discussion
   date: 20210608
   time_start: "14:15"
   time_end: "15:00"
   session: breakout
-  platform: Zoom 2
+  platform: Zoom B
 - name: Social break
   date: 20210608
   time_start: "15:00"
@@ -107,13 +107,13 @@
   time_start: "15:15"
   time_end: "16:00"
   session: workshop
-  platform: Zoom 1
+  platform: Zoom A
 - name: Focused discussion
   date: 20210608
   time_start: "15:15"
   time_end: "16:00"
   session: breakout
-  platform: Zoom 2
+  platform: Zoom B
 - name: Closing remarks
   date: 20210608
   time_start: "16:00"


### PR DESCRIPTION
There are signs in Gather.Town for the parallel sessions, referring to each space as zoom (room) A and B. On the website, it was 1 and 2. It's easier to change the website (and suggested change on the email template) than the sign inside the Gather space.