### PR TITLE
Add session URLs and change active break platform

### DIFF
--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -2,19 +2,19 @@
   date: 20210607
   time_start: "13:00"
   time_end: "13:15"
-  platform: Crowdcast+https://www.crowdcast.io/e/2u50rd1n
+  platform: Crowdcast+https://www.crowdcast.io/e/2u50rd1n/1
   youtube: https://youtu.be/g_5-h7QPSkg
 - name: Keynote talk
   date: 20210607
   time_start: "13:15"
   time_end: "14:15"
-  platform: Crowdcast+https://www.crowdcast.io/e/2u50rd1n
+  platform: Crowdcast+https://www.crowdcast.io/e/2u50rd1n/2
   youtube: https://youtu.be/DBPuwN_Hdic
 - name: Lightning talks
   date: 20210607
   time_start: "14:20"
   time_end: "14:50"
-  platform: Crowdcast+https://www.crowdcast.io/e/2u50rd1n
+  platform: Crowdcast+https://www.crowdcast.io/e/2u50rd1n/3
   youtube: https://youtu.be/NZuI3IzxNu8
 - name: Lightning talks Q&A + Social
   date: 20210607
@@ -26,12 +26,12 @@
   time_start: "15:10"
   time_end: "15:15"
   session: activebreak
-  platform: Crowdcast
+  platform: Gather.town+https://gather.town/i/e7LPsVjS
 - name: Keynote talk
   date: 20210607
   time_start: "15:15"
   time_end: "16:15"
-  platform: Crowdcast+https://www.crowdcast.io/e/2u50rd1n
+  platform: Crowdcast+https://www.crowdcast.io/e/2u50rd1n/5
   youtube: https://youtu.be/jLsAnQN69mQ
 - name: Social break
   date: 20210607
@@ -43,19 +43,19 @@
   time_start: "16:25"
   time_end: "16:30"
   session: activebreak
-  platform: Crowdcast
+  platform: Gather.town+https://gather.town/i/e7LPsVjS
 - name: Panel discussion
   date: 20210607
   time_start: "16:30"
   time_end: "17:15"
   session: panel
-  platform: Crowdcast+https://www.crowdcast.io/e/2u50rd1n
+  platform: Crowdcast+https://www.crowdcast.io/e/2u50rd1n/7
   youtube: https://youtu.be/FIsNN2Fc1vc
 - name: Closing remarks
   date: 20210607
   time_start: "17:15"
   time_end: "17:30"
-  platform: Crowdcast+https://www.crowdcast.io/e/2u50rd1n
+  platform: Crowdcast+https://www.crowdcast.io/e/2u50rd1n/8
   youtube: https://youtu.be/pkMXuO_tChY
 
 - name: Opening remarks


### PR DESCRIPTION
1. I modified the Crowdcast URLs so that each session is linked to the corresponding session within the Crowdcast event.
2. I also changed the platform of active breaks to Gather.town. I didn't know if it's possible to have multiple links that's not platform/Youtube combo, so I didn't keep the Crowdcast link.