### PR TITLE
Ayuno mods

### DIFF
--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -140,6 +140,7 @@
   date: 20210608
   time_start: "15:10"
   time_end: "15:15"
+  session: break
   platforms: 
     - Gather.town+https://gather.town/i/e7LPsVjS
 - name: Workshop

--- a/_data/speakers.yml
+++ b/_data/speakers.yml
@@ -149,7 +149,7 @@
   sessions: 
   - "202106071505activebreak"
   - "202106071620activebreak"
-  - "202106081510activebreak"
+  - "202106081505activebreak"
   affiliations:
   - Department of Health, Kinesiology and Clinical Exercise Physiology at Concordia University
   photo: caelan_taylor.jpg


### PR DESCRIPTION
On the Schedule data, session type was added to the transition period after the active break so that it does not appear bold.

On Speakers data, the 3rd active break time was changed to match the schedule (i.e. 5 min earlier).